### PR TITLE
Fix DNC tag styling not being applied

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -94,7 +94,6 @@ public class PersonCard extends UiPart<Region> {
         } else {
             dncLabel.setVisible(false);
             dncLabel.setManaged(false);
-            
             if (person.getTags().isEmpty()) {
                 tags.setManaged(false);
                 tags.setVisible(false);


### PR DESCRIPTION
DNC tag now shows unique styling
<img width="949" height="193" alt="image" src="https://github.com/user-attachments/assets/4845627f-083f-4307-ac5f-76a6962d4934" />

Fixes #105 