### PR TITLE
Update constraints for age

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -144,15 +144,26 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String age} into an {@code Age}.
-     * Leading and trailing whitespaces will be trimmed.
+     * Parses {@code String age} into an {@code Age}.
+     * Leading whitespace and trailing whitespace will be trimmed.
      *
      * @throws ParseException if the given {@code age} is invalid.
      */
     public static Age parseAge(String age) throws ParseException {
         requireNonNull(age);
         String trimmedAge = age.trim();
-        if (!Age.isValidAge(trimmedAge)) {
+
+        // Normalize age by removing leading zeros before validation
+        String normalizedAge = trimmedAge;
+        if (!trimmedAge.isEmpty()) {
+            try {
+                normalizedAge = String.valueOf(Integer.parseInt(trimmedAge));
+            } catch (NumberFormatException e) {
+                throw new ParseException(Age.MESSAGE_CONSTRAINTS);
+            }
+        }
+
+        if (!Age.isValidAge(normalizedAge)) {
             throw new ParseException(Age.MESSAGE_CONSTRAINTS);
         }
         return new Age(trimmedAge);

--- a/src/main/java/seedu/address/model/person/Age.java
+++ b/src/main/java/seedu/address/model/person/Age.java
@@ -10,8 +10,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Age {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Age should be a non-negative integer with at most 3 digits.";
+            "Age should be between 10 and 120 (inclusive).";
     public static final String VALIDATION_REGEX = "\\d{1,3}";
+    public static final int MIN_AGE = 10;
+    public static final int MAX_AGE = 120;
     public final String value;
 
     /**
@@ -21,21 +23,36 @@ public class Age {
      */
     public Age(String age) {
         requireNonNull(age);
-        checkArgument(isValidAge(age), MESSAGE_CONSTRAINTS);
 
         if (age.isEmpty()) {
             value = age;
         } else {
             // Remove leading zeros by parsing as integer and converting back to string
-            value = String.valueOf(Integer.parseInt(age));
+            String normalizedAge = String.valueOf(Integer.parseInt(age));
+            checkArgument(isValidAge(normalizedAge), MESSAGE_CONSTRAINTS);
+            value = normalizedAge;
         }
     }
 
     /**
      * Returns true if a given string is a valid age.
+     * Valid age must be empty or a number between 10 and 120 (inclusive).
      */
     public static boolean isValidAge(String test) {
-        return test.isEmpty() || test.matches(VALIDATION_REGEX);
+        if (test.isEmpty()) {
+            return true;
+        }
+
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        try {
+            int ageValue = Integer.parseInt(test);
+            return ageValue >= MIN_AGE && ageValue <= MAX_AGE;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -264,7 +264,15 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, () -> ParserUtil.parseAge("12.5"));
         assertThrows(ParseException.class, () -> ParserUtil.parseAge("-5"));
         assertThrows(ParseException.class, () -> ParserUtil.parseAge("20a"));
+
         assertThrows(ParseException.class, () -> ParserUtil.parseAge("1234")); // more than 3 digits
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseAge("5")); // below minimum age
+        assertThrows(ParseException.class, () -> ParserUtil.parseAge("9")); // below minimum age
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseAge("1234")); // more than 3 digits
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseAge("5")); // below minimum age
     }
 
     @Test
@@ -294,27 +302,33 @@ public class ParserUtilTest {
         assertEquals(expectedAge20, ParserUtil.parseAge("020"));
         assertEquals("20", ParserUtil.parseAge("020").value);
 
-        // Leading zero with single digit result
-        Age expectedAge5 = new Age("5");
-        assertEquals(expectedAge5, ParserUtil.parseAge("05"));
-        assertEquals("5", ParserUtil.parseAge("05").value);
+        // Multiple leading zeros - 4 digits becomes valid 2 digits
+        assertEquals(expectedAge20, ParserUtil.parseAge("0020"));
+        assertEquals("20", ParserUtil.parseAge("0020").value);
 
-        // All zeros except last digit
-        Age expectedAge1 = new Age("1");
-        assertEquals(expectedAge1, ParserUtil.parseAge("001"));
-        assertEquals("1", ParserUtil.parseAge("001").value);
+        // Leading zero with two digit result
+        Age expectedAge15 = new Age("15");
+        assertEquals(expectedAge15, ParserUtil.parseAge("015"));
+        assertEquals("15", ParserUtil.parseAge("015").value);
 
-        // Just zero
-        Age expectedAge0 = new Age("0");
-        assertEquals(expectedAge0, ParserUtil.parseAge("00"));
-        assertEquals("0", ParserUtil.parseAge("00").value);
-        assertEquals(expectedAge0, ParserUtil.parseAge("000"));
-        assertEquals("0", ParserUtil.parseAge("000").value);
+        // Leading zeros with minimum valid age
+        Age expectedAge10 = new Age("10");
+        assertEquals(expectedAge10, ParserUtil.parseAge("010"));
+        assertEquals("10", ParserUtil.parseAge("010").value);
+
+        // 4 digits with leading zeros becomes valid minimum age
+        assertEquals(expectedAge10, ParserUtil.parseAge("0010"));
+        assertEquals("10", ParserUtil.parseAge("0010").value);
 
         // Three digit age without leading zeros should remain unchanged
         Age expectedAge100 = new Age("100");
         assertEquals(expectedAge100, ParserUtil.parseAge("100"));
         assertEquals("100", ParserUtil.parseAge("100").value);
+
+        // Maximum valid age
+        Age expectedAge120 = new Age("120");
+        assertEquals(expectedAge120, ParserUtil.parseAge("120"));
+        assertEquals("120", ParserUtil.parseAge("120").value);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/AgeTest.java
+++ b/src/test/java/seedu/address/model/person/AgeTest.java
@@ -1,0 +1,168 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class AgeTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Age(null));
+    }
+
+    @Test
+    public void constructor_invalidAge_throwsIllegalArgumentException() {
+        String invalidAge = "abc";
+        assertThrows(IllegalArgumentException.class, () -> new Age(invalidAge));
+
+        // More than 3 digits after removing leading zeros
+        assertThrows(IllegalArgumentException.class, () -> new Age("1234"));
+
+        // Below minimum age (10) - even with leading zeros
+        assertThrows(IllegalArgumentException.class, () -> new Age("5"));
+        assertThrows(IllegalArgumentException.class, () -> new Age("9"));
+        assertThrows(IllegalArgumentException.class, () -> new Age("0"));
+        assertThrows(IllegalArgumentException.class, () -> new Age("00005")); // becomes 5 after normalization
+
+        // Above maximum age (120)
+        assertThrows(IllegalArgumentException.class, () -> new Age("121"));
+        assertThrows(IllegalArgumentException.class, () -> new Age("150"));
+        assertThrows(IllegalArgumentException.class, () -> new Age("999"));
+    }
+
+    @Test
+    public void constructor_leadingZeros_removesLeadingZeros() {
+        // Single leading zero - two digit result
+        Age age1 = new Age("020");
+        assertEquals("20", age1.value);
+
+        // Multiple leading zeros - 4 digits becomes 2 digits
+        Age age2 = new Age("0020");
+        assertEquals("20", age2.value);
+
+        // Single leading zero - minimum valid age
+        Age age3 = new Age("010");
+        assertEquals("10", age3.value);
+
+        // Multiple leading zeros - 4 digits becomes minimum valid age
+        Age age4 = new Age("0010");
+        assertEquals("10", age4.value);
+
+        // All zeros except last digit - within valid range
+        Age age5 = new Age("015");
+        assertEquals("15", age5.value);
+
+        // No leading zeros - should remain unchanged
+        Age age6 = new Age("100");
+        assertEquals("100", age6.value);
+
+        Age age7 = new Age("25");
+        assertEquals("25", age7.value);
+
+        // Maximum valid age
+        Age age8 = new Age("120");
+        assertEquals("120", age8.value);
+
+        // Minimum valid age
+        Age age9 = new Age("10");
+        assertEquals("10", age9.value);
+    }
+
+    @Test
+    public void isValidAge() {
+        // null age
+        assertThrows(NullPointerException.class, () -> Age.isValidAge(null));
+
+        // invalid ages - non-numeric or wrong format
+        assertFalse(Age.isValidAge("abc")); // non-numeric
+        assertFalse(Age.isValidAge("12.5")); // decimal
+        assertFalse(Age.isValidAge("-5")); // negative
+        assertFalse(Age.isValidAge("20a")); // contains letter
+        assertFalse(Age.isValidAge("1234")); // more than 3 digits
+        assertFalse(Age.isValidAge("a20")); // starts with letter
+
+        // invalid ages - outside valid range (10-120)
+        assertFalse(Age.isValidAge("0")); // below minimum
+        assertFalse(Age.isValidAge("5")); // below minimum
+        assertFalse(Age.isValidAge("9")); // below minimum
+        assertFalse(Age.isValidAge("121")); // above maximum
+        assertFalse(Age.isValidAge("150")); // above maximum
+        assertFalse(Age.isValidAge("999")); // above maximum
+
+        // valid ages
+        assertTrue(Age.isValidAge("")); // empty string
+        assertTrue(Age.isValidAge("10")); // minimum valid age
+        assertTrue(Age.isValidAge("25")); // typical age
+        assertTrue(Age.isValidAge("65")); // typical age
+        assertTrue(Age.isValidAge("100")); // three digits
+        assertTrue(Age.isValidAge("120")); // maximum valid age
+        assertTrue(Age.isValidAge("020")); // with leading zeros (valid after parsing)
+        assertTrue(Age.isValidAge("010")); // with leading zeros (valid after parsing)
+    }
+
+    @Test
+    public void equals() {
+        Age age = new Age("25");
+
+        // same values -> returns true
+        assertTrue(age.equals(new Age("25")));
+
+        // same object -> returns true
+        assertTrue(age.equals(age));
+
+        // null -> returns false
+        assertFalse(age.equals(null));
+
+        // different types -> returns false
+        assertFalse(age.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(age.equals(new Age("30")));
+
+        // leading zeros removed - should be equal
+        Age ageWithLeadingZero = new Age("025");
+        assertTrue(age.equals(ageWithLeadingZero));
+        assertTrue(ageWithLeadingZero.equals(age));
+
+        // another test with leading zeros
+        Age age1 = new Age("010");
+        Age age2 = new Age("10");
+        assertTrue(age1.equals(age2));
+        assertTrue(age2.equals(age1));
+    }
+
+    @Test
+    public void hashCode_equalAges_sameHashCode() {
+        Age age1 = new Age("25");
+        Age age2 = new Age("025");
+
+        // Ages with leading zeros should be equal and have same hash code
+        assertEquals(age1, age2);
+        assertEquals(age1.hashCode(), age2.hashCode());
+
+        Age age3 = new Age("010");
+        Age age4 = new Age("10");
+
+        assertEquals(age3, age4);
+        assertEquals(age3.hashCode(), age4.hashCode());
+    }
+
+    @Test
+    public void toString_validAge_returnsCorrectString() {
+        assertEquals("25", new Age("25").toString());
+        assertEquals("100", new Age("100").toString());
+        assertEquals("", new Age("").toString());
+        assertEquals("10", new Age("10").toString());
+        assertEquals("120", new Age("120").toString());
+
+        // Leading zeros removed in toString
+        assertEquals("20", new Age("020").toString());
+        assertEquals("10", new Age("010").toString());
+        assertEquals("15", new Age("015").toString());
+    }
+}
+


### PR DESCRIPTION
Removed leading zeros, and accept ages between 10 and 120 inclusive.

with added testing for new implementation

fixes #240 
fixes #225 